### PR TITLE
pr263 Add the new `style_*_leading_space` rules to ruleset-style.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9097,7 +9097,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary boolean operators.
+Put exactly one space before binary arithmetic operators.
 
 ### Reason
 
@@ -9273,7 +9273,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary boolean operators.
+Put exactly one space before binary boolean operators.
 
 ### Reason
 
@@ -9415,7 +9415,7 @@ See also:
 
 ### Hint
 
-Put exact one space before binary integer operators.
+Put exactly one space before binary integer operators.
 
 ### Reason
 
@@ -11335,6 +11335,9 @@ syntaxrules.style_operator_arithmetic = true
 syntaxrules.style_operator_boolean = true
 syntaxrules.style_operator_integer = true
 syntaxrules.style_operator_unary = true
+syntaxrules.style_operator_arithmetic_leading_space = true
+syntaxrules.style_operator_boolean_leading_space = true
+syntaxrules.style_operator_integer_leading_space = true
 
 syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true

--- a/md/ruleset-style.md
+++ b/md/ruleset-style.md
@@ -219,6 +219,9 @@ syntaxrules.style_operator_arithmetic = true
 syntaxrules.style_operator_boolean = true
 syntaxrules.style_operator_integer = true
 syntaxrules.style_operator_unary = true
+syntaxrules.style_operator_arithmetic_leading_space = true
+syntaxrules.style_operator_boolean_leading_space = true
+syntaxrules.style_operator_integer_leading_space = true
 
 syntaxrules.style_keyword_0or1space = true
 syntaxrules.style_keyword_0space = true


### PR DESCRIPTION
I thought this might be quicker than writing a comment on <https://github.com/dalance/svlint/pull/263> :p

To add rules to a ruleset, modify `md/ruleset-foo.md` then rerun `cargo run --bin=mdgen`.
This also puts the spelling change into `MANUAL.md`.

If you accept and merge this PR, then the changes will appear <https://github.com/dalance/svlint/pull/263>.
If not, I'm pretty sure that CI will fail (when dalance approves the runs).